### PR TITLE
Fix cast in serializeValue

### DIFF
--- a/source/mir/ion/ser/package.d
+++ b/source/mir/ion/ser/package.d
@@ -86,7 +86,7 @@ void serializeValue(S, V)(ref S serializer, const V value)
 void serializeValue(S, V : char)(ref S serializer, const V value)
     if (is(V == char) && !is(V == enum))
 {
-    auto v = cast(char[1])value;
+    char[1] v = value;
     serializer.putValue(v[]);
 }
 


### PR DESCRIPTION
Running the following sample program:

```D
import mir.ion.ser.json : serializeJson;
import mir.appender : ScopedBuffer;
import mir.small_string;

void main()
{
    SmallString!8 smll = SmallString!8("ciaociao");
    ScopedBuffer!char buffer;

    serializeJson(buffer, smll);
}
```
Results in the following error:

```
mir-ion/source/mir/ion/ser/package.d(89,27): Error: cannot cast expression value of type const(char) to char[1]
```
The culprit of this seems to be the cast from char to char[1] which fails in the `serializeValue` overload which is handling char serialization. The strange thing is that casting (`auto v = cast(char[1])value`) doesn't work while direct assignment does: `char[1] v = value` builds correctly. Is there any difference between the two I'm not aware of?