### PR TITLE
Various lexer fixes (addresses #153)

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -14,7 +14,6 @@ configuration "common" {
 }
 
 configuration "unittest" {
-    dependency "unit-threaded" version="~>1.0.11"
     buildOptions "unittests" "debugMode" "debugInfo"
     dflags "-lowmem"
     versions "mir_ion_test" "mir_ion_parser_test"

--- a/meson.build
+++ b/meson.build
@@ -16,6 +16,7 @@ sources_list = [
     'mir/ion/deser/text/skippers',
     'mir/ion/deser/text/tokenizer',
     'mir/ion/deser/text/tokens',
+    'mir/ion/deser/text/package',
     'mir/ion/deser/json',
     'mir/ion/deser/low_level',
     'mir/ion/deser/package',

--- a/source/mir/ion/deser/text/readers.d
+++ b/source/mir/ion/deser/text/readers.d
@@ -135,6 +135,9 @@ if (isInstanceOf!(IonTokenizer, T) && is(T.inputType == ubyte)) {
 /// Test reading a unicode escape
 version(mir_ion_parser_test) unittest
 {
+    import mir.ion.deser.text.tokenizer : tokenizeString;
+    import mir.ion.deser.text.tokens : MirIonTokenizerException;
+
     void test(string ts, dchar expected) {
         auto t = tokenizeString(ts);
         assert(t.readEscapedChar() == expected);
@@ -208,6 +211,9 @@ if (isInstanceOf!(IonTokenizer, T) && is(T.inputType == ubyte)) {
 /// Test reading a symbol
 version(mir_ion_parser_test) unittest
 {
+    import mir.ion.deser.text.tokenizer : tokenizeString;
+    import mir.ion.deser.text.tokens : MirIonTokenizerException, IonTokenType;
+
     void test(string ts, string expected, IonTokenType after) {
         import std.exception : assertNotThrown;
         auto t = tokenizeString(ts); 
@@ -257,6 +263,9 @@ if (isInstanceOf!(IonTokenizer, T) && is(T.inputType == ubyte)) {
 /// Test reading quoted symbols
 version(mir_ion_parser_test) unittest
 {
+    import mir.ion.deser.text.tokenizer : tokenizeString;
+    import mir.ion.deser.text.tokens : IonTokenType;
+
     void test(string ts, string expected, ubyte after) {
         auto t = tokenizeString(ts);
         assert(t.nextToken());
@@ -363,6 +372,9 @@ if (isInstanceOf!(IonTokenizer, T) && is(T.inputType == ubyte)) {
 /// Test reading a string
 version(mir_ion_parser_test) unittest
 {
+    import mir.ion.deser.text.tokenizer : tokenizeString;
+    import mir.ion.deser.text.tokens : IonTokenType;
+
     void test(string ts, string expected, ubyte after) {
         auto t = tokenizeString(ts);
         assert(t.nextToken());
@@ -395,6 +407,9 @@ if (isInstanceOf!(IonTokenizer, T) && is(T.inputType == ubyte)) {
 /// Test reading a long string
 version(mir_ion_parser_test) unittest
 {
+    import mir.ion.deser.text.tokenizer : tokenizeString;
+    import mir.ion.deser.text.tokens : IonTokenType;
+
     void test(string ts, string expected, ubyte after) {
         auto t = tokenizeString(ts);
         assert(t.nextToken());
@@ -437,6 +452,9 @@ if (isInstanceOf!(IonTokenizer, T) && is(T.inputType == ubyte)) {
 /// Test reading a short clob
 version(mir_ion_parser_test) unittest
 {
+    import mir.ion.deser.text.tokenizer : tokenizeString;
+    import mir.ion.deser.text.tokens : IonTokenType;
+
     void test(string ts, string expected, ubyte after) {
         auto t = tokenizeString(ts);
         assert(t.nextToken());
@@ -573,7 +591,10 @@ if (isInstanceOf!(IonTokenizer, T) && is(T.inputType == ubyte)) {
 /// Test reading numbers
 version(mir_ion_parser_test) unittest
 {
+    import mir.ion.deser.text.tokenizer : tokenizeString;
+    import mir.ion.deser.text.tokens : IonTokenType;
     import mir.ion.type_code : IonTypeCode;
+
     void test(string ts, string expected, IonTypeCode type, ubyte after) {
         auto t = tokenizeString(ts);
         assert(t.nextToken());
@@ -689,6 +710,9 @@ if (isInstanceOf!(IonTokenizer, T) && is(T.inputType == ubyte)) {
 /// Test reading a binary number
 version(mir_ion_parser_test) unittest
 {
+    import mir.ion.deser.text.tokenizer : tokenizeString;
+    import mir.ion.deser.text.tokens : IonTokenType;
+
     void test(string ts, string expected, ubyte after) {
         auto t = tokenizeString(ts);
         assert(t.nextToken());
@@ -718,6 +742,9 @@ if (isInstanceOf!(IonTokenizer, T) && is(T.inputType == ubyte)) {
 /// Test reading a hex number
 version(mir_ion_parser_test) unittest
 {
+    import mir.ion.deser.text.tokenizer : tokenizeString;
+    import mir.ion.deser.text.tokens : IonTokenType;
+
     void test(string ts, string expected, ubyte after) {
         auto t = tokenizeString(ts);
         assert(t.nextToken());
@@ -849,6 +876,9 @@ if (isInstanceOf!(IonTokenizer, T) && is(T.inputType == ubyte)) {
 /// Test reading timestamps
 version(mir_ion_parser_test) unittest
 {
+    import mir.ion.deser.text.tokenizer : tokenizeString;
+    import mir.ion.deser.text.tokens : IonTokenType;
+
     void test(string ts, string expected, ubyte after) {
         auto t = tokenizeString(ts);
         assert(t.nextToken());

--- a/source/mir/ion/deser/text/readers.d
+++ b/source/mir/ion/deser/text/readers.d
@@ -9,7 +9,6 @@ import mir.ion.deser.text.skippers;
 import mir.ion.deser.text.tokens;
 import std.traits : isInstanceOf;
 import mir.appender : ScopedBuffer;
-version(mir_ion_parser_test) import unit_threaded;
 
 // MASSIVE TODO: check if we ever will run into the ScopedBuffers running out of memory!
 // IIRC, they *do* not allocate above their max of 1024, so we may *need* to verify this is correct
@@ -133,17 +132,18 @@ if (isInstanceOf!(IonTokenizer, T) && is(T.inputType == ubyte)) {
             throw new MirIonTokenizerException(text("bad escape 0x", c, " (location: ", t.position, ")"));
     }
 }
-///
-version(mir_ion_parser_test) @("Test reading a unicode escape") unittest
+/// Test reading a unicode escape
+version(mir_ion_parser_test) unittest
 {
     void test(string ts, dchar expected) {
         auto t = tokenizeString(ts);
-        t.readEscapedChar().shouldEqual(expected);
+        assert(t.readEscapedChar() == expected);
     }
 
     void testFail(string ts) {
+        import std.exception : assertThrown;
         auto t = tokenizeString(ts);
-        t.readEscapedChar().shouldThrow();
+        assertThrown!MirIonTokenizerException(t.readEscapedChar());
     }
 
     test("U0001F44D", '\U0001F44D');
@@ -205,16 +205,17 @@ if (isInstanceOf!(IonTokenizer, T) && is(T.inputType == ubyte)) {
 
     return buf.data.idup;
 }
-///
-version(mir_ion_parser_test) @("Test reading a symbol") unittest
+/// Test reading a symbol
+version(mir_ion_parser_test) unittest
 {
     void test(string ts, string expected, IonTokenType after) {
+        import std.exception : assertNotThrown;
         auto t = tokenizeString(ts); 
-        t.nextToken().shouldNotThrow();
-        t.currentToken.shouldEqual(IonTokenType.TokenSymbol);
-        t.readSymbol().shouldEqual(expected);
-        t.nextToken().shouldNotThrow();
-        t.currentToken.shouldEqual(after);
+        assertNotThrown!MirIonTokenizerException(t.nextToken());
+        assert(t.currentToken == IonTokenType.TokenSymbol);
+        assert(t.readSymbol() == expected);
+        assertNotThrown!MirIonTokenizerException(t.nextToken());
+        assert(t.currentToken == after);
     }
 
     test("hello", "hello", IonTokenType.TokenEOF);
@@ -253,15 +254,15 @@ if (isInstanceOf!(IonTokenizer, T) && is(T.inputType == ubyte)) {
         }
     }
 }
-///
-version(mir_ion_parser_test) @("Test reading quoted symbols") unittest
+/// Test reading quoted symbols
+version(mir_ion_parser_test) unittest
 {
     void test(string ts, string expected, ubyte after) {
         auto t = tokenizeString(ts);
-        t.nextToken().shouldEqual(true);
-        t.currentToken.shouldEqual(IonTokenType.TokenSymbolQuoted);
-        t.readSymbolQuoted().shouldEqual(expected);
-        t.readInput().shouldEqual(after);
+        assert(t.nextToken());
+        assert(t.currentToken == IonTokenType.TokenSymbolQuoted);
+        assert(t.readSymbolQuoted() == expected);
+        assert(t.readInput() == after);
     }
 
     test("'a'", "a", 0);
@@ -359,15 +360,15 @@ if (isInstanceOf!(IonTokenizer, T) && is(T.inputType == ubyte)) {
     }
     assert(0);
 }
-///
-version(mir_ion_parser_test) @("Test reading a string") unittest
+/// Test reading a string
+version(mir_ion_parser_test) unittest
 {
     void test(string ts, string expected, ubyte after) {
         auto t = tokenizeString(ts);
-        t.nextToken().shouldEqual(true);
-        t.currentToken.shouldEqual(IonTokenType.TokenString);
-        t.readString().shouldEqual(expected);
-        t.readInput().shouldEqual(after);
+        assert(t.nextToken());
+        assert(t.currentToken == IonTokenType.TokenString);
+        assert(t.readString() == expected);
+        assert(t.readInput() == after);
     }
 
     test(`"Hello, world"`, "Hello, world", 0);
@@ -391,15 +392,15 @@ const(char)[] readLongString(T)(ref T t)
 if (isInstanceOf!(IonTokenizer, T) && is(T.inputType == ubyte)) {
     return readString!(T, true)(t);
 }
-///
-version(mir_ion_parser_test) @("Test reading a long string") unittest
+/// Test reading a long string
+version(mir_ion_parser_test) unittest
 {
     void test(string ts, string expected, ubyte after) {
         auto t = tokenizeString(ts);
-        t.nextToken().shouldEqual(true);
-        t.currentToken.shouldEqual(IonTokenType.TokenLongString);
-        t.readLongString().shouldEqual(expected);
-        t.readInput().shouldEqual(after);
+        assert(t.nextToken());
+        assert(t.currentToken == IonTokenType.TokenLongString);
+        assert(t.readLongString() == expected);
+        assert(t.readInput() == after);
     }
 
     test(`'''Hello, world'''`, "Hello, world", 0);
@@ -433,15 +434,15 @@ if (isInstanceOf!(IonTokenizer, T) && is(T.inputType == ubyte)) {
     t.finished = true; // we're done reading!
     return data;
 }
-///
-version(mir_ion_parser_test) @("Test reading a short clob") unittest
+/// Test reading a short clob
+version(mir_ion_parser_test) unittest
 {
     void test(string ts, string expected, ubyte after) {
         auto t = tokenizeString(ts);
-        t.nextToken().shouldEqual(true);
-        t.currentToken.shouldEqual(IonTokenType.TokenString);
-        t.readClob().shouldEqual(expected);
-        t.readInput().shouldEqual(after);
+        assert(t.nextToken());
+        assert(t.currentToken == IonTokenType.TokenString);
+        assert(t.readClob() == expected);
+        assert(t.readInput() == after);
     }
 
     test(`"Hello, world"}}`, "Hello, world", 0);
@@ -569,18 +570,18 @@ if (isInstanceOf!(IonTokenizer, T) && is(T.inputType == ubyte)) {
 
     return num; 
 }
-///
-version(mir_ion_parser_test) @("Test reading numbers") unittest
+/// Test reading numbers
+version(mir_ion_parser_test) unittest
 {
     import mir.ion.type_code : IonTypeCode;
     void test(string ts, string expected, IonTypeCode type, ubyte after) {
         auto t = tokenizeString(ts);
-        t.nextToken().shouldEqual(true);
-        t.currentToken.shouldEqual(IonTokenType.TokenNumber);
+        assert(t.nextToken());
+        assert(t.currentToken == IonTokenType.TokenNumber);
         auto n = t.readNumber();
-        n.val.shouldEqual(expected);
-        n.type.shouldEqual(type);
-        t.readInput().shouldEqual(after);
+        assert(n.val == expected);
+        assert(n.type == type);
+        assert(t.readInput() == after);
     }
 
     test("12341", "12341", IonTypeCode.uInt, 0);
@@ -685,15 +686,15 @@ string readBinary(T)(ref T t)
 if (isInstanceOf!(IonTokenizer, T) && is(T.inputType == ubyte)) {
     return readRadix!(T, "a == 'b' || a == 'B'", "a == '0' || a == '1'")(t);
 }
-///
-version(mir_ion_parser_test) @("Test reading a binary number") unittest
+/// Test reading a binary number
+version(mir_ion_parser_test) unittest
 {
     void test(string ts, string expected, ubyte after) {
         auto t = tokenizeString(ts);
-        t.nextToken().shouldEqual(true);
-        t.currentToken.shouldEqual(IonTokenType.TokenBinary);
-        t.readBinary().shouldEqual(expected);
-        t.readInput().shouldEqual(after);
+        assert(t.nextToken());
+        assert(t.currentToken == IonTokenType.TokenBinary);
+        assert(t.readBinary() == expected);
+        assert(t.readInput() == after);
     }
 
     test("0b101011010", "0b101011010", 0);
@@ -714,15 +715,15 @@ string readHex(T)(ref T t)
 if (isInstanceOf!(IonTokenizer, T) && is(T.inputType == ubyte)) {
     return readRadix!(T, "a == 'x' || a == 'X'", isHexDigit)(t);
 }
-///
-version(mir_ion_parser_test) @("Test reading a hex number") unittest
+/// Test reading a hex number
+version(mir_ion_parser_test) unittest
 {
     void test(string ts, string expected, ubyte after) {
         auto t = tokenizeString(ts);
-        t.nextToken().shouldEqual(true);
-        t.currentToken.shouldEqual(IonTokenType.TokenHex);
-        t.readHex().shouldEqual(expected);
-        t.readInput().shouldEqual(after);
+        assert(t.nextToken());
+        assert(t.currentToken == IonTokenType.TokenHex);
+        assert(t.readHex() == expected);
+        assert(t.readInput() == after);
     } 
 
     test("0xBADBABE", "0xBADBABE", 0);
@@ -845,15 +846,15 @@ if (isInstanceOf!(IonTokenizer, T) && is(T.inputType == ubyte)) {
     c = readTSOffsetOrZ(c);
     return readTSFinish(c);
 }
-///
-version(mir_ion_parser_test) @("Test reading timestamps") unittest
+/// Test reading timestamps
+version(mir_ion_parser_test) unittest
 {
     void test(string ts, string expected, ubyte after) {
         auto t = tokenizeString(ts);
-        t.nextToken().shouldEqual(true);
-        t.currentToken.shouldEqual(IonTokenType.TokenTimestamp);
-        t.readTimestamp().shouldEqual(expected);
-        t.readInput().shouldEqual(after);
+        assert(t.nextToken());
+        assert(t.currentToken == IonTokenType.TokenTimestamp);
+        assert(t.readTimestamp() == expected);
+        assert(t.readInput() == after);
     } 
 
     test("2001T", "2001T", 0);

--- a/source/mir/ion/deser/text/skippers.d
+++ b/source/mir/ion/deser/text/skippers.d
@@ -9,7 +9,6 @@ import mir.ion.deser.text.tokens;
 import mir.ion.type_code;
 import std.traits : isInstanceOf;
 import std.range;
-version(mir_ion_parser_test) import unit_threaded;
 
 @safe:
 /++
@@ -95,21 +94,21 @@ if (isInstanceOf!(IonTokenizer, T)) {
         }
     }
 }
-///
-version(mir_ion_parser_test) @("Test skipping of a single-line comment") unittest 
+/// Test skipping over single-line comments.
+version(mir_ion_parser_test) unittest 
 {
     auto t = tokenizeString("single-line comment\r\nok");
-    t.skipSingleLineComment().shouldEqual(true);
+    assert(t.skipSingleLineComment());
 
     t.testRead('o');
     t.testRead('k');
     t.testRead(0);
 }
-///
-version(mir_ion_parser_test) @("Test skipping of a single-line comment on the last line") unittest
+/// Test skipping of a single-line comment on the last line
+version(mir_ion_parser_test) unittest
 {
     auto t = tokenizeString("single-line comment");
-    t.skipSingleLineComment().shouldEqual(true);
+    assert(t.skipSingleLineComment());
     t.testRead(0);
 }
 
@@ -137,17 +136,17 @@ if (isInstanceOf!(IonTokenizer, T)) {
         }
     }
 }
-///
-version(mir_ion_parser_test) @("Test skipping of an invalid comment") unittest
+/// Test skipping of an invalid comment
+version(mir_ion_parser_test) unittest
 {
     auto t = tokenizeString("this is a string that never ends");
-    t.skipBlockComment().shouldEqual(false);
+    assert(!t.skipBlockComment());
 }
-///
-version(mir_ion_parser_test) @("Test skipping of a block comment") unittest
+/// Test skipping of a multi-line comment
+version(mir_ion_parser_test) unittest
 {
     auto t = tokenizeString("this is/ a\nmulti-line /** comment.**/ok");
-    t.skipBlockComment().shouldEqual(true);
+    assert(t.skipBlockComment());
 
     t.testRead('o');
     t.testRead('k');
@@ -178,29 +177,29 @@ if (isInstanceOf!(IonTokenizer, T)) {
 
     return false;
 }
-///
-version(mir_ion_parser_test) @("Test different skipping methods (single-line)") unittest
+/// Test single-line skipping
+version(mir_ion_parser_test) unittest
 {
     auto t = tokenizeString("/comment\nok");
-    t.skipComment().shouldEqual(true);
+    assert(t.skipComment());
     t.testRead('o');
     t.testRead('k');
     t.testRead(0);
 }
-///
-version(mir_ion_parser_test) @("Test different skipping methods (block)") unittest
+/// Test block skipping
+version(mir_ion_parser_test) unittest
 {
     auto t = tokenizeString("*comm\nent*/ok");
-    t.skipComment().shouldEqual(true);
+    assert(t.skipComment());
     t.testRead('o');
     t.testRead('k');
     t.testRead(0);
 }
-///
-version(mir_ion_parser_test) @("Test different skipping methods (false-alarm)") unittest
+/// Test false-alarm skipping
+version(mir_ion_parser_test) unittest
 {
     auto t = tokenizeString(" 0)");
-    t.skipComment().shouldEqual(false);
+    assert(!t.skipComment());
     t.testRead(' ');
     t.testRead('0');
     t.testRead(')');
@@ -254,17 +253,18 @@ if (isInstanceOf!(IonTokenizer, T)) {
 
     return t.expect!(t.isStopChar, true)(c);
 }
-///
-version(mir_ion_parser_test) @("Test skipping over numbers") unittest
+/// Test skipping over numbers
+version(mir_ion_parser_test) unittest
 {
     void test(string ts, ubyte expected) {
         auto t = tokenizeString(ts);
-        t.skipNumber().shouldEqual(expected);
+        assert(t.skipNumber() == expected);
     }
 
     void testFail(string ts) {
+        import std.exception : assertThrown;
         auto t = tokenizeString(ts);
-        t.skipNumber().shouldThrow();
+        assertThrown!MirIonTokenizerException(t.skipNumber());
     }
 
     test("", 0);
@@ -287,17 +287,18 @@ T.inputType skipBinary(T)(ref T t)
 if (isInstanceOf!(IonTokenizer, T)) {
     return skipRadix!(T, "a == 'b' || a == 'B'", "a == '0' || a == '1'")(t);   
 }
-///
-version(mir_ion_parser_test) @("Test skipping over binary numbers") unittest
+/// Test skipping over binary numbers
+version(mir_ion_parser_test) unittest
 {
     void test(string ts, ubyte expected) {
         auto t = tokenizeString(ts);
-        t.skipBinary().shouldEqual(expected);
+        assert(t.skipBinary() == expected);
     }
 
     void testFail(string ts) {
+        import std.exception : assertThrown;
         auto t = tokenizeString(ts);
-        t.skipBinary().shouldThrow();
+        assertThrown!MirIonTokenizerException(t.skipBinary());
     }
 
     test("0b0", 0);
@@ -318,17 +319,18 @@ T.inputType skipHex(T)(ref T t)
 if (isInstanceOf!(IonTokenizer, T)) {
     return skipRadix!(T, "a == 'x' || a == 'X'", isHexDigit)(t); 
 }
-///
-version(mir_ion_parser_test) @("Test skipping over hex numbers") unittest
+/// Test skipping over hex numbers
+version(mir_ion_parser_test) unittest
 {
     void test(string ts, ubyte expected) {
         auto t = tokenizeString(ts);
-        t.skipHex().shouldEqual(expected);
+        assert(t.skipHex() == expected);
     }
 
     void testFail(string ts) {
+        import std.exception : assertThrown;
         auto t = tokenizeString(ts);
-        t.skipHex().shouldThrow();
+        assertThrown!MirIonTokenizerException(t.skipHex());
     }
 
     test("0xDEADBABE,0xDEADBABE", ',');
@@ -469,17 +471,18 @@ if (isInstanceOf!(IonTokenizer, T)) {
     T.inputType afterOffsetNS = skipTSOffsetOrZ(offsetNS);
     return skipTSFinish(afterOffsetNS);  
 }
-///
-version(mir_ion_parser_test) @("Test skipping over timestamps") unittest
+/// Test skipping over timestamps
+version(mir_ion_parser_test) unittest
 {
     void test(string ts, ubyte result) {
         auto t = tokenizeString(ts);
-        t.skipTimestamp().shouldEqual(result);
+        assert(t.skipTimestamp() == result);
     }
 
     void testFail(string ts) {
+        import std.exception : assertThrown;
         auto t = tokenizeString(ts);
-        t.skipTimestamp().shouldThrow();
+        assertThrown!MirIonTokenizerException(t.skipTimestamp());
     }
 
     test("2001T", 0);
@@ -526,12 +529,12 @@ if (isInstanceOf!(IonTokenizer, T)) {
 
     return c;
 }
-///
-version(mir_ion_parser_test) @("Test skipping over symbols") unittest
+/// Test skipping over symbols
+version(mir_ion_parser_test) unittest
 {
     void test(string ts, ubyte result) {
         auto t = tokenizeString(ts);
-        t.skipSymbol().shouldEqual(result);
+        assert(t.skipSymbol() == result);
     }
 
     test("f", 0);
@@ -579,17 +582,18 @@ if (isInstanceOf!(IonTokenizer, T)) {
     t.skipSymbolQuotedInternal();
     return t.readInput();  
 }
-///
-version(mir_ion_parser_test) @("Test skipping over quoted symbols") unittest
+/// Test skipping over quoted symbols
+version(mir_ion_parser_test) unittest
 {
     void test(string ts, ubyte result) {
         auto t = tokenizeString(ts);
-        t.skipSymbolQuoted().shouldEqual(result);
+        assert(t.skipSymbolQuoted() == result);
     }
 
     void testFail(string ts) {
+        import std.exception : assertThrown;
         auto t = tokenizeString(ts);
-        t.skipSymbolQuoted().shouldThrow();
+        assertThrown!MirIonTokenizerException(t.skipSymbolQuoted());
     }
 
     test("'", 0);
@@ -616,12 +620,12 @@ if (isInstanceOf!(IonTokenizer, T)) {
     }
     return c; 
 }
-///
-version(mir_ion_parser_test) @("Test skipping over symbol operators") unittest
+/// Test skipping over symbol operators
+version(mir_ion_parser_test) unittest
 {
     void test(string ts, ubyte result) {
         auto t = tokenizeString(ts);
-        t.skipSymbolOperator().shouldEqual(result);
+        assert(t.skipSymbolOperator() == result);
     }
 
     test("+", 0);
@@ -664,17 +668,18 @@ if (isInstanceOf!(IonTokenizer, T)) {
     t.skipStringInternal();
     return t.readInput();  
 }
-///
-version(mir_ion_parser_test) @("Test skipping over strings") unittest
+/// Test skipping over strings
+version(mir_ion_parser_test) unittest
 {
     void test(string ts, ubyte result) {
         auto t = tokenizeString(ts);
-        t.skipString().shouldEqual(result);
+        assert(t.skipString() == result);
     }
 
     void testFail(string ts) {
+        import std.exception : assertThrown;
         auto t = tokenizeString(ts);
-        t.skipString().shouldThrow();
+        assertThrown!MirIonTokenizerException(t.skipString());
     }
 
     test("\"", 0);
@@ -749,12 +754,12 @@ if (isInstanceOf!(IonTokenizer, T)) {
     skipLongStringInternal!(T, true, false)(t);
     return t.readInput();
 }
-///
-version(mir_ion_parser_test) @("Test skipping over long strings") unittest
+/// Test skipping over long strings
+version(mir_ion_parser_test) unittest
 {
     void test(string ts, ubyte result) {
         auto t = tokenizeString(ts);
-        t.skipLongString().shouldEqual(result);
+        assert(t.skipLongString() == result);
     }
 
 }
@@ -771,12 +776,12 @@ if (isInstanceOf!(IonTokenizer, T)) {
     t.skipBlobInternal();
     return t.readInput();  
 }
-///
-version(mir_ion_parser_test) @("Test skipping over blobs") unittest
+/// Test skipping over blobs
+version(mir_ion_parser_test) unittest
 {
     void test(string ts, ubyte result) {
         auto t = tokenizeString(ts);
-        t.skipBlob().shouldEqual(result);
+        assert(t.skipBlob() == result);
     } 
 
     test("}}", 0);
@@ -813,12 +818,12 @@ T.inputType skipStruct(T)(ref T t)
 if (isInstanceOf!(IonTokenizer, T)) {
     return skipContainer!T(t, '}');
 }
-///
-version(mir_ion_parser_test) @("Test skipping over structs") unittest
+/// Test skipping over structs
+version(mir_ion_parser_test) unittest
 {
     void test(string ts, ubyte result) {
         auto t = tokenizeString(ts);
-        t.skipStruct().shouldEqual(result);
+        assert(t.skipStruct() == result);
     }
 
     test("},", ',');
@@ -848,12 +853,12 @@ T.inputType skipSexp(T)(ref T t)
 if (isInstanceOf!(IonTokenizer, T)) {
     return skipContainer!T(t, ')');
 }
-///
-version(mir_ion_parser_test) @("Test skipping over S-Exps") unittest
+/// Test skipping over S-expressions
+version(mir_ion_parser_test) unittest
 {
     void test(string ts, ubyte result) {
         auto t = tokenizeString(ts);
-        t.skipSexp().shouldEqual(result);
+        assert(t.skipSexp() == result);
     }
 
     test("1231 + 1123),", ',');
@@ -882,12 +887,12 @@ T.inputType skipList(T)(ref T t)
 if (isInstanceOf!(IonTokenizer, T)) {
     return skipContainer!T(t, ']'); 
 }
-///
-version(mir_ion_parser_test) @("Test skipping over a list") unittest
+/// Test skipping over lists
+version(mir_ion_parser_test) unittest
 {
     void test(string ts, ubyte result) {
         auto t = tokenizeString(ts);
-        t.skipList().shouldEqual(result);
+        assert(t.skipList() == result);
     }
 
     test("\"foo\", \"bar\", \"baz\"],", ',');

--- a/source/mir/ion/deser/text/skippers.d
+++ b/source/mir/ion/deser/text/skippers.d
@@ -97,6 +97,7 @@ if (isInstanceOf!(IonTokenizer, T)) {
 /// Test skipping over single-line comments.
 version(mir_ion_parser_test) unittest 
 {
+    import mir.ion.deser.text.tokenizer : tokenizeString, testRead;
     auto t = tokenizeString("single-line comment\r\nok");
     assert(t.skipSingleLineComment());
 
@@ -107,6 +108,7 @@ version(mir_ion_parser_test) unittest
 /// Test skipping of a single-line comment on the last line
 version(mir_ion_parser_test) unittest
 {
+    import mir.ion.deser.text.tokenizer : tokenizeString, testRead;
     auto t = tokenizeString("single-line comment");
     assert(t.skipSingleLineComment());
     t.testRead(0);
@@ -139,12 +141,14 @@ if (isInstanceOf!(IonTokenizer, T)) {
 /// Test skipping of an invalid comment
 version(mir_ion_parser_test) unittest
 {
+    import mir.ion.deser.text.tokenizer : tokenizeString;
     auto t = tokenizeString("this is a string that never ends");
     assert(!t.skipBlockComment());
 }
 /// Test skipping of a multi-line comment
 version(mir_ion_parser_test) unittest
 {
+    import mir.ion.deser.text.tokenizer : tokenizeString, testRead;
     auto t = tokenizeString("this is/ a\nmulti-line /** comment.**/ok");
     assert(t.skipBlockComment());
 
@@ -180,6 +184,7 @@ if (isInstanceOf!(IonTokenizer, T)) {
 /// Test single-line skipping
 version(mir_ion_parser_test) unittest
 {
+    import mir.ion.deser.text.tokenizer : tokenizeString, testRead;
     auto t = tokenizeString("/comment\nok");
     assert(t.skipComment());
     t.testRead('o');
@@ -189,6 +194,7 @@ version(mir_ion_parser_test) unittest
 /// Test block skipping
 version(mir_ion_parser_test) unittest
 {
+    import mir.ion.deser.text.tokenizer : tokenizeString, testRead;
     auto t = tokenizeString("*comm\nent*/ok");
     assert(t.skipComment());
     t.testRead('o');
@@ -198,6 +204,7 @@ version(mir_ion_parser_test) unittest
 /// Test false-alarm skipping
 version(mir_ion_parser_test) unittest
 {
+    import mir.ion.deser.text.tokenizer : tokenizeString, testRead;
     auto t = tokenizeString(" 0)");
     assert(!t.skipComment());
     t.testRead(' ');
@@ -256,6 +263,9 @@ if (isInstanceOf!(IonTokenizer, T)) {
 /// Test skipping over numbers
 version(mir_ion_parser_test) unittest
 {
+    import mir.ion.deser.text.tokenizer : tokenizeString;
+    import mir.ion.deser.text.tokens : MirIonTokenizerException;
+
     void test(string ts, ubyte expected) {
         auto t = tokenizeString(ts);
         assert(t.skipNumber() == expected);
@@ -290,6 +300,9 @@ if (isInstanceOf!(IonTokenizer, T)) {
 /// Test skipping over binary numbers
 version(mir_ion_parser_test) unittest
 {
+    import mir.ion.deser.text.tokenizer : tokenizeString;
+    import mir.ion.deser.text.tokens : MirIonTokenizerException;
+
     void test(string ts, ubyte expected) {
         auto t = tokenizeString(ts);
         assert(t.skipBinary() == expected);
@@ -322,6 +335,9 @@ if (isInstanceOf!(IonTokenizer, T)) {
 /// Test skipping over hex numbers
 version(mir_ion_parser_test) unittest
 {
+    import mir.ion.deser.text.tokenizer : tokenizeString;
+    import mir.ion.deser.text.tokens : MirIonTokenizerException;
+
     void test(string ts, ubyte expected) {
         auto t = tokenizeString(ts);
         assert(t.skipHex() == expected);
@@ -474,6 +490,9 @@ if (isInstanceOf!(IonTokenizer, T)) {
 /// Test skipping over timestamps
 version(mir_ion_parser_test) unittest
 {
+    import mir.ion.deser.text.tokenizer : tokenizeString;
+    import mir.ion.deser.text.tokens : MirIonTokenizerException;
+
     void test(string ts, ubyte result) {
         auto t = tokenizeString(ts);
         assert(t.skipTimestamp() == result);
@@ -532,6 +551,8 @@ if (isInstanceOf!(IonTokenizer, T)) {
 /// Test skipping over symbols
 version(mir_ion_parser_test) unittest
 {
+    import mir.ion.deser.text.tokenizer : tokenizeString;
+
     void test(string ts, ubyte result) {
         auto t = tokenizeString(ts);
         assert(t.skipSymbol() == result);
@@ -585,6 +606,9 @@ if (isInstanceOf!(IonTokenizer, T)) {
 /// Test skipping over quoted symbols
 version(mir_ion_parser_test) unittest
 {
+    import mir.ion.deser.text.tokenizer : tokenizeString;
+    import mir.ion.deser.text.tokens : MirIonTokenizerException;
+
     void test(string ts, ubyte result) {
         auto t = tokenizeString(ts);
         assert(t.skipSymbolQuoted() == result);
@@ -623,6 +647,8 @@ if (isInstanceOf!(IonTokenizer, T)) {
 /// Test skipping over symbol operators
 version(mir_ion_parser_test) unittest
 {
+    import mir.ion.deser.text.tokenizer : tokenizeString;
+
     void test(string ts, ubyte result) {
         auto t = tokenizeString(ts);
         assert(t.skipSymbolOperator() == result);
@@ -671,6 +697,9 @@ if (isInstanceOf!(IonTokenizer, T)) {
 /// Test skipping over strings
 version(mir_ion_parser_test) unittest
 {
+    import mir.ion.deser.text.tokenizer : tokenizeString;
+    import mir.ion.deser.text.tokens : MirIonTokenizerException;
+ 
     void test(string ts, ubyte result) {
         auto t = tokenizeString(ts);
         assert(t.skipString() == result);
@@ -757,11 +786,12 @@ if (isInstanceOf!(IonTokenizer, T)) {
 /// Test skipping over long strings
 version(mir_ion_parser_test) unittest
 {
+    import mir.ion.deser.text.tokenizer : tokenizeString;
+
     void test(string ts, ubyte result) {
         auto t = tokenizeString(ts);
         assert(t.skipLongString() == result);
     }
-
 }
 
 /++
@@ -779,6 +809,8 @@ if (isInstanceOf!(IonTokenizer, T)) {
 /// Test skipping over blobs
 version(mir_ion_parser_test) unittest
 {
+    import mir.ion.deser.text.tokenizer : tokenizeString;
+
     void test(string ts, ubyte result) {
         auto t = tokenizeString(ts);
         assert(t.skipBlob() == result);
@@ -821,6 +853,8 @@ if (isInstanceOf!(IonTokenizer, T)) {
 /// Test skipping over structs
 version(mir_ion_parser_test) unittest
 {
+    import mir.ion.deser.text.tokenizer : tokenizeString;
+ 
     void test(string ts, ubyte result) {
         auto t = tokenizeString(ts);
         assert(t.skipStruct() == result);
@@ -856,6 +890,8 @@ if (isInstanceOf!(IonTokenizer, T)) {
 /// Test skipping over S-expressions
 version(mir_ion_parser_test) unittest
 {
+    import mir.ion.deser.text.tokenizer : tokenizeString;
+ 
     void test(string ts, ubyte result) {
         auto t = tokenizeString(ts);
         assert(t.skipSexp() == result);
@@ -890,6 +926,8 @@ if (isInstanceOf!(IonTokenizer, T)) {
 /// Test skipping over lists
 version(mir_ion_parser_test) unittest
 {
+    import mir.ion.deser.text.tokenizer : tokenizeString;
+ 
     void test(string ts, ubyte result) {
         auto t = tokenizeString(ts);
         assert(t.skipList() == result);

--- a/source/mir/ion/deser/text/tokenizer.d
+++ b/source/mir/ion/deser/text/tokenizer.d
@@ -262,6 +262,9 @@ if (isValidTokenizerInput!(Input)) {
     version(mir_ion_parser_test) unittest
     {
         import std.exception : assertThrown;
+        import mir.exception : enforce;
+        import mir.ion.deser.text.tokens : MirIonTokenizerException;
+
         auto t = tokenizeString("abc\r\ndef");
         
         assert(t.peekExactly(1) == "a");
@@ -279,8 +282,8 @@ if (isValidTokenizerInput!(Input)) {
         t.testRead('\n');
         t.testRead('d');
 
-        assertThrown!MirIonTokenizerException(t.peekExactly(3) == "ef");
-        assertThrown!MirIonTokenizerException(t.peekExactly(3) == "ef");
+        assertThrown!MirIonTokenizerException(enforce!"Did not match"(t.peekExactly(3) == "ef"));
+        assertThrown!MirIonTokenizerException(enforce!"Did not match"(t.peekExactly(3) == "ef"));
         assert(t.peekExactly(2) == "ef");
 
         t.testRead('e');
@@ -320,6 +323,8 @@ if (isValidTokenizerInput!(Input)) {
     version(mir_ion_parser_test) unittest
     {
         import std.exception : assertThrown;
+        import mir.ion.deser.text.tokens : MirIonTokenizerException;
+
         auto t = tokenizeString("abc");
 
         t.testPeek('a');
@@ -450,9 +455,10 @@ if (isValidTokenizerInput!(Input)) {
     /// Test skipping over whitespace 
     version(mir_ion_parser_test) unittest
     {
+        import std.exception : assertNotThrown;
+        import mir.exception : enforce;
+        import mir.ion.deser.text.tokens : MirIonTokenizerException;
         void test(string txt, ubyte expectedChar) {
-            import std.exception : assertNotThrown;
-            import mir.exception : enforce;
             auto t = tokenizeString(txt);
             assertNotThrown!MirIonTokenizerException(enforce!"skipWhitespace did not return expected character"(t.skipWhitespace() == expectedChar));
         }
@@ -482,9 +488,10 @@ if (isValidTokenizerInput!(Input)) {
     /// Test skipping over whitespace within a (c|b)lob
     version(mir_ion_parser_test) unittest
     {
+        import std.exception : assertNotThrown;
+        import mir.exception : enforce;
+        import mir.ion.deser.text.tokens : MirIonTokenizerException;
         void test(string txt, ubyte expectedChar)() {
-            import std.exception : assertNotThrown;
-            import mir.exception : enforce;
             auto t = tokenizeString(txt);
             assertNotThrown!MirIonTokenizerException(enforce!"Lob whitespace did not match expecte character"(t.skipLobWhitespace() == expectedChar));
         }
@@ -634,6 +641,8 @@ if (isValidTokenizerInput!(Input)) {
     /// Test scanning for numbers 
     version(mir_ion_parser_test) unittest
     {
+        import mir.ion.deser.text.tokens : IonTokenType;
+
         void test(string txt, IonTokenType expectedToken) {
             auto t = tokenizeString(txt);
             auto c = t.readInput();
@@ -920,6 +929,9 @@ if (isValidTokenizerInput!(Input)) {
     /// Text expect()
     version(mir_ion_parser_test) unittest
     {
+        import mir.ion.deser.text.tokens : MirIonTokenizerException, isHexDigit;
+        import std.range : empty;
+
         void testIsHex(string ts) {
             auto t = tokenizeString(ts);
             while (!t.input.empty) {
@@ -981,18 +993,14 @@ if (isValidTokenizerInput!(Input)) {
             }
         }
     }
-
-
 }
-
-version(mir_ion_parser_test):
 
 /++
 Generic helper to verify the functionality of the parsing code in unit-tests
 +/
 template testRead(T, string file = __FILE__, int line = __LINE__) {
     void testRead(ref T t, ubyte expected) {
-        import mir.exception;
+        import mir.exception : MirError;
         ubyte v = t.readInput();
         if (v != expected) {
             import mir.format;
@@ -1007,7 +1015,7 @@ Generic helper to verify the functionality of the parsing code in unit-tests
 +/
 template testPeek(T, string file = __FILE__, int line = __LINE__) {
     void testPeek(ref T t, ubyte expected) {
-        import mir.exception;
+        import mir.exception : MirError;
         ubyte v = t.peekOne();
         if (v != expected) {
             import mir.format;

--- a/source/mir/ion/deser/text/tokens.d
+++ b/source/mir/ion/deser/text/tokens.d
@@ -88,7 +88,6 @@ enum IonTokenType : ubyte
     /++ }} +/ 
     TokenCloseDoubleBrace
 }
-
 ///
 version(mir_ion_test) unittest 
 {


### PR DESCRIPTION
This PR addresses #153:

- [x] remove unit_threaded
- [ ] fix `std.range` imports
- [ ] make code less generic (only allow for `const(char)[]` input)