### PR TITLE
Hard-lock external CI actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       - name: Set up D compiler / tools
-        uses: dlang-community/setup-dlang@v1.1.0
+        uses: dlang-community/setup-dlang@763d869b4d67e50c3ccd142108c8bca2da9df166
         with:
           compiler: ldc-latest
       - name: Run unittests
@@ -45,10 +45,10 @@ jobs:
             os: macos-latest
             arch: x86_64
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
         with:
           fetch-depth: 0
-      - uses: dlang-community/setup-dlang@v1.1.0
+      - uses: dlang-community/setup-dlang@763d869b4d67e50c3ccd142108c8bca2da9df166
         with:
           compiler: ${{ matrix.dc }}
       - name: Install multi-lib for 32-bit systems
@@ -59,4 +59,4 @@ jobs:
         run: dub test --arch=$ARCH --build=unittest-cov
         shell: bash
       - id: coverage
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b


### PR DESCRIPTION
This PR will hard-lock external CI actions, so as to prevent any significant breakages from any updates.