### PR TITLE
add check for KeyType.serdeIgnoreOut

### DIFF
--- a/source/mir/ion/examples.d
+++ b/source/mir/ion/examples.d
@@ -370,14 +370,36 @@ version(mir_ion_test) unittest
     import mir.ser.json;
     import mir.deser.json;
 
+    static struct CustomType
+    {
+        int a;
+
+        // can be part of a type as well (only omits on property keys)
+        bool serdeIgnoreOut() const
+        {
+            return a < 0;
+        }
+
+        // and use custom serializer to serialize as int
+        void serialize(S)(ref S serializer) const
+        {
+            import mir.ser : serializeValue;
+
+            serializeValue(serializer, a);
+        }
+    }
+
     static struct S
     {
         @serdeIgnoreOutIf!`a < 0`
         int a;
+
+        // b is not output if the serdeIgnoreOut property in its type evaluates to false.
+        CustomType b;
     }
 
-    assert(serializeJson(S(3)) == `{"a":3}`, serializeJson(S(3)));
-    assert(serializeJson(S(-3)) == `{}`);
+    assert(serializeJson(S(3, CustomType(2))) == `{"a":3,"b":2}`, serializeJson(S(3, CustomType(2))));
+    assert(serializeJson(S(-3, CustomType(-2))) == `{}`);
 }
 
 ///

--- a/source/mir/ser/package.d
+++ b/source/mir/ser/package.d
@@ -509,6 +509,12 @@ void serializeValueImpl(S, V)(ref S serializer, auto ref V value)
                     continue;
             }
 
+            static if(__traits(hasMember, typeof(__traits(getMember, value, member)), "serdeIgnoreOut"))
+            {
+                if (__traits(getMember, __traits(getMember, value, member), "serdeIgnoreOut"))
+                    continue;
+            }
+
             static if(hasUDA!(__traits(getMember, value, member), serdeTransformOut))
             {
                 alias f = serdeGetTransformOut!(__traits(getMember, value, member));


### PR DESCRIPTION
Turns out my feature request in #13 would have been too complex to add and there existed `serdeIgnoreOutIf` already which did exactly what I wanted, but on the value.

So I just added code to check on the type `serdeIgnoreOut` that if it evaluates to true, does not emit the value.

Sample SumType / Optional implementation:

```d
struct NoneType {}
alias Optional(T) = MySumType!(NoneType, T);

struct MySumType(Types...)
{
	import std.typecons;
	SumType!Types value;
	mixin Proxy!value;

	enum hasNoneType = () {
		bool has = false;
		foreach (Type; Types)
			static if (is(Type == NoneType))
				has = true;
		return has;
	}();

	static if (hasNoneType)
		bool serdeIgnoreOut() const
		{
			return value.tryMatch!(
				(NoneType none) => true,
				v => false
			);
		}

	void serialize(S)(ref S serializer) const
	{
		import mir.ser : serializeValue;

		static if (hasNoneType)
			value.tryMatch!(
				(NoneType none) => assert(false),
				v => serializeValue(serializer, v)
			);
		else
			value.tryMatch!(
				v => serializeValue(serializer, v)
			);
	}
}
```

Might want to consider if this should also apply to array values.