### PR TITLE
apply serdeIgnoreOut to `void` Variants

### DIFF
--- a/source/mir/ser/package.d
+++ b/source/mir/ser/package.d
@@ -551,6 +551,12 @@ void serializeValueImpl(S, V)(scope ref S serializer, auto ref V value)
                     continue;
             }
 
+            static if(__traits(hasMember, typeof(__traits(getMember, value, member)), "_void"))
+            {
+                if (__traits(getMember, value, member) == typeof(__traits(getMember, value, member))._void)
+                    continue;
+            }
+
             static if(hasUDA!(__traits(getMember, value, member), serdeTransformOut))
             {
                 alias f = serdeGetTransformOut!(__traits(getMember, value, member));


### PR DESCRIPTION
just checks if the type has a `_void` symbol and the value itself is
equal to it, thus also allowing other types to behave similarly.