### PR TITLE
Simplify deserialize on Variant!(void, T)

### DIFF
--- a/source/mir/deser/package.d
+++ b/source/mir/deser/package.d
@@ -1360,7 +1360,8 @@ template deserializeValue(string[] symbolTable, TableKind tableKind)
                 return retNull;
             }
         }
-        static if ((contains!(typeof(null)) || contains!IonNull) && T.AllowedTypes.length == 2)
+        static if (T.AllowedTypes.length == 2
+            && (contains!(typeof(null)) || contains!IonNull || is(T.AllowedTypes[0] == void)))
         {
             T.AllowedTypes[1] payload;
             if (auto exception = deserializeValue(data, payload, table, tableIndex))

--- a/source/mir/ion/examples.d
+++ b/source/mir/ion/examples.d
@@ -1408,7 +1408,7 @@ version(mir_ion_test) unittest
 version(mir_ion_test) unittest
 {
     import mir.serde: serdeEnumProxy;
-    import mir.algebraic: Nullable, nullable;
+    import mir.algebraic: Nullable, Variant, nullable;
 
     @serdeEnumProxy!string
     enum StrE : string
@@ -1420,13 +1420,15 @@ version(mir_ion_test) unittest
     static struct S
     {
         Nullable!(StrE[]) a;
+        Variant!(void, StrE) b;
     }
 
     import mir.ser.json : serializeJson;
     import mir.deser.json : deserializeJson;
 
     auto s = S([StrE.one, StrE.two, cast(StrE)"drei"].nullable);
-    auto str = `{"a":["eins","zwei","drei"]}`;
+    s.b = StrE.two;
+    auto str = `{"a":["eins","zwei","drei"],"b":"zwei"}`;
 
     assert(str.deserializeJson!S == s);
     assert(s.serializeJson == str, str);


### PR DESCRIPTION
There was a special case for Nullable, I also applied this to Variants with void in first place. This is used heavily in serve-d.

Additionally it seems Variants don't actually support the serdeEnumProxy properly that was present in the here adjusted test. However with Nullable and now with Variant!(void, T) they at least work, which should cover a lot of cases. In serve-d there is only a single exception to this, to which I simply implemented a custom wrapper struct for serialization around.