### PR TITLE
Fix #30 library build breaks in release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,10 +107,14 @@ jobs:
           key: ubuntu-latest-build-${{ hashFiles('**/dub.sdl', '**/dub.json') }}
           restore-keys: |
             ubuntu-latest-build-
-      - name: Build / test 
+      - name: Build / test
         run: |
-          # dub test --build=unittest-release
           dub test --arch=$ARCH --build=unittest
+        shell: bash
+      - name: Build / test (Release mode)
+        if: ${{ contains(matrix.dc, 'ldc') }}
+        run: |
+          dub test --arch=$ARCH --build=unittest-release
         shell: bash
       - name: Upload coverage data
         uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b

--- a/source/mir/deser/text/package.d
+++ b/source/mir/deser/text/package.d
@@ -136,7 +136,7 @@ private:
 
     static void __bar()
     {
-        typeof(this).init.ser.putAnnotation("symbolText");
+        typeof(*typeof(this).init.ser).init.putAnnotation("symbolText");
     }
 
     static assert(__traits(compiles, (){__bar();}));


### PR DESCRIPTION
`typeof(this).init.ser` defaults to a null pointer, so we init that value instead here to fix the issue in #30.

Building a release library works now.	