### PR TITLE
fix integration test compile time error

### DIFF
--- a/ion-integration-tester/source/tests/cases.d
+++ b/ion-integration-tester/source/tests/cases.d
@@ -80,7 +80,7 @@ void testEquivs(Test test) {
             IonSexp sexp = ionValue.get!(IonSexp);
             IonDescribedValue first;
             int i = 0;
-            foreach(IonDescribedValue value; sexp) {
+            foreach(scope IonDescribedValue value; sexp) {
                 if (i++ == 0) {
                     first = value;
                 }
@@ -96,7 +96,7 @@ void testEquivs(Test test) {
             IonList list = ionValue.get!(IonList);
             IonDescribedValue first;
             int i = 0;
-            foreach(IonDescribedValue value; list) {
+            foreach(scope IonDescribedValue value; list) {
                 if (i++ == 0) {
                     first = value;
                 } else {
@@ -124,7 +124,7 @@ void testNonEquivs(Test test) {
             IonSexp sexp = ionValue.get!(IonSexp);
             IonDescribedValue first;
             int i = 0;
-            foreach(IonDescribedValue value; sexp) {
+            foreach(scope IonDescribedValue value; sexp) {
                 if (i++ == 0) {
                     first = value;
                 }
@@ -140,7 +140,7 @@ void testNonEquivs(Test test) {
             IonList list = ionValue.get!(IonList);
             IonDescribedValue first;
             int i = 0;
-            foreach(IonDescribedValue value; list) {
+            foreach(scope IonDescribedValue value; list) {
                 if (i++ == 0) {
                     first = value;
                 } else {


### PR DESCRIPTION
it still fails now, but at least now the CI runs the actual integration tests

```
Running test case (name: Known-good Ion data, expectedFail: false)
[✓] good/allNulls.ion
[✓] good/annotationQuotedFalse.ion
[✓] good/annotationQuotedNan.ion
[✓] good/annotationQuotedNegInf.ion
[✓] good/annotationQuotedNull.ion
[✓] good/annotationQuotedNullInt.ion
[✓] good/annotationQuotedOperator.ion
[✓] good/annotationQuotedPosInf.ion
[✓] good/annotationQuotedTrue.ion
[✓] good/blobs.ion
[✓] good/booleans.ion
[✓] good/clobWithDel.10n
[✓] good/clobWithDel.ion
[✓] good/clobWithNonAsciiCharacter.10n
[✓] good/clobWithNullCharacter.10n
[✓] good/clobs.ion
[✓] good/clobsWithQuotes.ion
[✓] good/clobsWithWhitespace.ion
[✓] good/commentMultiLineThenEof.ion
[✓] good/commentSingleLineThenEof.ion
[✓] good/decimal64BitBoundary.ion
[✓] good/decimalNegativeOneDotTwoEight.ion
[✓] good/decimalNegativeOneDotZero.10n
[✓] good/decimalNegativeZeroDot.10n
[✓] good/decimalNegativeZeroDotZero.10n
[✓] good/decimalOneDotZero.10n
[✓] good/decimalWithTerminatingEof.ion
[✓] good/decimalZeroDot.10n
[✓] good/decimal_e_values.ion
[✓] good/decimal_values.ion
[✓] good/decimal_zeros.ion
[✓] good/decimalsWithUnderscores.ion
[✗] good/emptyThreeByteNopPad.10n
    mir.ion.exception.IonException: IonException: unexpected NOP Padding (file: ../source/mir/ion/exception.d:287)
[✓] good/eolCommentCr.ion
[✓] good/eolCommentCrLf.ion
[✓] good/fieldNameInf.ion
[✓] good/fieldNameQuotedFalse.ion
[✓] good/fieldNameQuotedNan.ion
[✓] good/fieldNameQuotedNegInf.ion
[✓] good/fieldNameQuotedNull.ion
[✓] good/fieldNameQuotedNullInt.ion
[✓] good/fieldNameQuotedPosInf.ion
[✓] good/fieldNameQuotedTrue.ion
[✓] good/float32.10n
[✓] good/floatDblMax.ion
[✓] good/floatDblMin.ion
[✓] good/floatSpecials.ion
[✓] good/floatWithTerminatingEof.ion
[✓] good/float_trapped_zeros.ion
[✓] good/float_values.ion
[✓] good/float_zeros.ion
[✓] good/floatsWithUnderscores.ion
[✓] good/hexWithTerminatingEof.ion
[✓] good/innerVersionIdentifiers.ion
[✗] good/intBigSize1201.10n
    core.exception.ArraySliceError: slice [0 .. 32765] extends past source array of length 128 (file: ../../../.dub/packages/mir-algorithm-3.16.12/mir-algorithm/source/mir/bignum/integer.d:326)

----- SUMMARY -----
166 registered tests
Ran 55 tests
   53 test(s) passed
   2 test(s) failed
Took 30 msecs
Total pass rate: 96.36%
Program exited with code 1
```