### PR TITLE
Disable ion2MyFormat in docs

### DIFF
--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -24,6 +24,6 @@ jobs:
         with:
           compiler: dmd-latest
       - name: Fetch 'md' tool
-        run: dub fetch md
+        run: dub fetch md@0.5.0-beta
       - name: Test custom-formats.md
         run: dub run md -- docs-src/custom-formats.md

--- a/docs-src/custom-formats.md
+++ b/docs-src/custom-formats.md
@@ -325,7 +325,7 @@ transactions:
 
 Conversion from binary Ion to your format can be done as follow:
 
-``` d
+``` d disabled
 auto ion2MyFormat(scope const(ubyte)[] data)
 {
     import mir.ion.stream: IonValueStream;


### PR DESCRIPTION
The example serializer doesn't implement all the needed things and UFCS doesn't work with `md` because everything is put into a `main` function.

~~The CI is still broken right now until there is a new `md` release though. After that it should be working again.~~ Beta is released now, using it in the CI until there is a stable version, from which point we can always fetch latest stable.