### PR TITLE
Fix weird compile errors with D v2.104+

### DIFF
--- a/source/mir/ser/package.d
+++ b/source/mir/ser/package.d
@@ -524,13 +524,13 @@ private void serializeValueImpl(S, V)(scope ref S serializer, scope ref const V 
                     continue;
             }
 
-            static if(__traits(hasMember, typeof(__traits(getMember, value, member)), "serdeIgnoreOut"))
+            static if(__traits(hasMember, __traits(getMember, value, member), "serdeIgnoreOut"))
             {
                 if (__traits(getMember, __traits(getMember, value, member), "serdeIgnoreOut"))
                     continue;
             }
 
-            static if(__traits(hasMember, typeof(__traits(getMember, value, member)), "_void"))
+            static if(__traits(hasMember, __traits(getMember, value, member), "_void"))
             {
                 if (__traits(getMember, value, member)._is!void)
                     continue;


### PR DESCRIPTION
AFAICT, the `typeof()` here should be superfluous, but isn't. We're seeing errors like
```
…\mir-ion\source\mir\ser\package.d(529): Error: cannot implicitly convert expression `value.message` of type `const(BrowserAction)` to `serdeIgnoreOut`
…\mir-ion\source\mir\ser\package.d(1020): Error: template instance `mir.ser.serializeValueImpl!(JsonSerializer!("", Appender!(char[])), Message!(BrowserAction))` error instantiating
```
with D v2.104.2 and v2.105.1, that are fixed by this.