### PR TITLE
internal/stage2.d: Use processor extensions in @target

### DIFF
--- a/source/mir/ion/internal/stage2.d
+++ b/source/mir/ion/internal/stage2.d
@@ -83,8 +83,13 @@ void stage2(
 
 version (X86_Any)
 {
+    // A backwards compatible @target ldc attribute.
+    // Needed because of https://github.com/libmir/mir-ion/pull/46
+    version(LDC)
+    private enum backwardsCompatibleTarget (string now, string old) =
+	target(__VERSION__ >= 2108 ? now : old);
 
-    version (LDC) @target("arch=westmere")
+    version (LDC) @backwardsCompatibleTarget!("sse4.2", "arch=westmere")
     private void stage2_impl_westmere(
         size_t n,
         scope const(ubyte[64])* vector,
@@ -121,7 +126,7 @@ version (X86_Any)
         while(--n);
     }
 
-    version (LDC) @target("arch=sandybridge")
+    version (LDC) @backwardsCompatibleTarget!("avx", "arch=sandybridge")
     private void stage2_impl_sandybridge(
         size_t n,
         scope const(ubyte[64])* vector,
@@ -158,7 +163,7 @@ version (X86_Any)
         while(--n);
     }
 
-    version (LDC) @target("arch=broadwell")
+    version (LDC) @backwardsCompatibleTarget!("avx2", "arch=broadwell")
     private void stage2_impl_broadwell(
         size_t n,
         scope const(ubyte[64])* vector,
@@ -197,7 +202,7 @@ version (X86_Any)
     }
 
     version(none)
-    version (LDC) @target("arch=skylake-avx512")
+    version (LDC) @backwardsCompatibleTarget!("avx512bw", "arch=skylake-avx512")
     private void stage2_impl_skylake_avx512(
         size_t n,
         scope const(ubyte[64])* vector,


### PR DESCRIPTION
With ldc2 -mcpu= or -mattr= can cause llvm internal errors:
```
SplitVectorResult #0: t15: v64i8 = llvm.x86.avx512.pshuf.b.512 TargetConstant:i64<11062>, t12, t13

LLVM ERROR: Do not know how to split the result of this operator!
 #0 0x00007f8cddc05505 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/usr/lib/llvm/17/lib64/libLLVM-17.so+0xa05505)
 #1 0x00007f8cddc02d8f llvm::sys::RunSignalHandlers() (/usr/lib/llvm/17/lib64/libLLVM-17.so+0xa02d8f)
 #2 0x00007f8cddc02f16 (/usr/lib/llvm/17/lib64/libLLVM-17.so+0xa02f16)
 #3 0x00007f8cdc793930 (/usr/lib64/libc.so.6+0x3a930)
 #4 0x00007f8cdc7e4e9c (/usr/lib64/libc.so.6+0x8be9c)
 #5 0x00007f8cdc793886 gsignal (/usr/lib64/libc.so.6+0x3a886)
 #6 0x00007f8cdc77b8b7 abort (/usr/lib64/libc.so.6+0x228b7)
 #7 0x00007f8cdd6d6c8c (/usr/lib/llvm/17/lib64/libLLVM-17.so+0x4d6c8c)
 #8 0x00007f8cddb2f9f5 llvm::report_fatal_error(char const*, bool) (/usr/lib/llvm/17/lib64/libLLVM-17.so+0x92f9f5)
 #9 0x00007f8cde6d27c3 (/usr/lib/llvm/17/lib64/libLLVM-17.so+0x14d27c3)
#10 0x00007f8cde66ded2 (/usr/lib/llvm/17/lib64/libLLVM-17.so+0x146ded2)
#11 0x00007f8cde66ec16 llvm::SelectionDAG::LegalizeTypes() (/usr/lib/llvm/17/lib64/libLLVM-17.so+0x146ec16)
#12 0x00007f8cde7e377a llvm::SelectionDAGISel::CodeGenAndEmitDAG() (/usr/lib/llvm/17/lib64/libLLVM-17.so+0x15e377a)
#13 0x00007f8cde7e8fe3 llvm::SelectionDAGISel::SelectAllBasicBlocks(llvm::Function const&) (/usr/lib/llvm/17/lib64/libLLVM-17.so+0x15e8fe3)
#14 0x00007f8cde7ea7e6 llvm::SelectionDAGISel::runOnMachineFunction(llvm::MachineFunction&) (/usr/lib/llvm/17/lib64/libLLVM-17.so+0x15ea7e6)
#15 0x00007f8ce1c2c089 (/usr/lib/llvm/17/lib64/libLLVM-17.so+0x4a2c089)
#16 0x00007f8cde131951 llvm::MachineFunctionPass::runOnFunction(llvm::Function&) (/usr/lib/llvm/17/lib64/libLLVM-17.so+0xf31951)
#17 0x00007f8cdddb4d0b llvm::FPPassManager::runOnFunction(llvm::Function&) (/usr/lib/llvm/17/lib64/libLLVM-17.so+0xbb4d0b)
#18 0x00007f8cdddb4f51 llvm::FPPassManager::runOnModule(llvm::Module&) (/usr/lib/llvm/17/lib64/libLLVM-17.so+0xbb4f51)
#19 0x00007f8cdddb59fd llvm::legacy::PassManagerImpl::run(llvm::Module&) (/usr/lib/llvm/17/lib64/libLLVM-17.so+0xbb59fd)
#20 0x000055a87ffc129b (anonymous namespace)::codegenModule(llvm::TargetMachine&, llvm::Module&, char const*, llvm::CodeGenFileType) /mnt/git/ldc/driver/toobj.cpp:146:14
#21 0x000055a87ffc2115 (anonymous namespace)::writeObjectFile(llvm::Module*, char const*) /mnt/git/ldc/driver/toobj.cpp:304:1
#22 0x000055a87ffc33ad writeModule(llvm::Module*, char const*) /mnt/git/ldc/driver/toobj.cpp:499:5
#23 0x000055a87ffbc291 ldc::CodeGenerator::writeAndFreeLLModule(char const*) /mnt/git/ldc/driver/codegenerator.cpp:295:7
#24 0x000055a87ffbbff7 ldc::CodeGenerator::finishLLModule(Module*) /mnt/git/ldc/driver/codegenerator.cpp:259:23
#25 0x000055a87ffbc507 ldc::CodeGenerator::emit(Module*) /mnt/git/ldc/driver/codegenerator.cpp:326:10
#26 0x000055a87ff74b5a codegenModules(Array<Module*>&) /mnt/git/ldc/driver/main.cpp:1304:7
#27 0x000055a87fc74731 mars_mainBody(Param&, Array<char const*>&, Array<char const*>&) /mnt/git/ldc/dmd/main.d:759:9
#28 0x000055a87ff74695 cppmain() /mnt/git/ldc/driver/main.cpp:1243:27
#29 0x000055a87fd905af D main /mnt/git/ldc/driver/main.d:28:1
#30 0x00007f8cdcf6f173 (/usr/lib/gcc/x86_64-pc-linux-gnu/13/libgphobos.so.4+0x56f173)
#31 0x00007f8cdcf6f82d (/usr/lib/gcc/x86_64-pc-linux-gnu/13/libgphobos.so.4+0x56f82d)
#32 0x00007f8cdcf6fa59 _d_run_main2 (/usr/lib/gcc/x86_64-pc-linux-gnu/13/libgphobos.so.4+0x56fa59)
#33 0x00007f8cdcf6fc27 _d_run_main (/usr/lib/gcc/x86_64-pc-linux-gnu/13/libgphobos.so.4+0x56fc27)
#34 0x000055a87ffb0efb args::forwardToDruntime(int, char const**) /mnt/git/ldc/driver/args.cpp:82:1
#35 0x000055a87ff73f3f main /mnt/git/ldc/driver/main.cpp:1123:33
#36 0x00007f8cdc77d2e0 (/usr/lib64/libc.so.6+0x242e0)
#37 0x00007f8cdc77d399 __libc_start_main (/usr/lib64/libc.so.6+0x24399)
#38 0x000055a87f9ae785 _start (/root/ldc-build/bin/ldc2+0x580785)
```

To reproduce this issue is should be enough to do:
```
DFLAGS='-mattr=-avx' dub build --compiler=ldc2
```

A fix seems to only use intrinsics that the target supports rather than using all of them and deciding at runtime which ones to use.

I've changed `sse4.2` to `ssse3` since this is what the intrinsics require., I'm not sure if this is a problem. I've hit this issue initially trying to compile `serve-d` with `ldc2` and `-mcpu=native`.